### PR TITLE
Fix Windows Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.a
 *.dSYM
 .DS_Store
+*.dll
+*.exe
 
 # Auto generated build files
 src/LOCATION
@@ -71,3 +73,12 @@ src/test_os_regex
 src/test_os_xml
 src/test_os_zlib
 src/test_shared
+
+# Windows-specific build output:
+src/win32/LICENSE.txt
+src/win32/default-local_internal_options.conf
+src/win32/default-ossec.conf
+src/win32/help_win.txt
+src/win32/internal_options.conf
+src/win32/restart-ossec.cmd
+src/win32/route-null.cmd

--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -14,7 +14,7 @@
 #define _WIN32_WINNT 0x0600
 
 /* Using Secure APIs */
-#define MINGW_HAS_SECURE_API
+#define MINGW_HAS_SECURE_API 1
 
 /* Bookmarks directory */
 #define BOOKMARKS_DIR "bookmarks"

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -256,8 +256,12 @@ static int read_sys_dir(const char *dir_name, int do_read)
             if (S_ISDIR(statbuf_local.st_mode))
 #else
             if (S_ISDIR(statbuf_local.st_mode) ||
-                    S_ISREG(statbuf_local.st_mode) ||
-                    S_ISLNK(statbuf_local.st_mode))
+                    S_ISREG(statbuf_local.st_mode)
+            /* No S_ISLNK on Windows */
+#ifndef WIN32
+		    || S_ISLNK(statbuf_local.st_mode)
+#endif
+		    )
 #endif
             {
                 entry_count++;


### PR DESCRIPTION
This PR fixes the following Windows-related build issues:

*S_ISLNK usage*
`S_ISLNK` isn't a supported call on Windows due to the lack of filesystem links like they exist on Unix-based systems. Other parts of the code properly check if WIN32 is defined, however, one piece was overlooked. This is fixed in one of the commits in this PR.

*MINGW_HAS_SECURE_API Incorrectly Used*
The `MINGW_HAS_SECURE_API` was used incorrectly and broke the Windows build - the correct usage is to define this to '1' instead of just defining it, as evident in the mingw headers.

*Add Windows-specific output to .gitignore*
Some of the build output files aren't added to the .gitignore, causing a potential source tree pollution when committing to the repository. Most notably, there was no exclusion for `*.exe` and `*.dll` files, while there was an exclusion for `.so` files. This discrepancy has been corrected.